### PR TITLE
Convert NixOS module to Home Manager module.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,59 @@
 {
   "nodes": {
     "home-manager": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      },
       "locked": {
-        "lastModified": 1672353432,
-        "narHash": "sha256-oZfgp/44/o2tWiylV30cR+DLyWTJ+5dhsdWZVpzs3e4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "913a47cd064cc06440ea84e5e0452039a85781f0",
+        "lastModified": 1672244468,
+        "narHash": "sha256-xaZb8AZqoXRCSqPusCk4ouf+fUNP8UJdafmMTF1Ltlw=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "89a8ba0b5b43b3350ff2e3ef37b66736b2ef8706",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-22.11",
-        "type": "indirect"
+        "owner": "nix-community",
+        "ref": "release-22.11",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1667629849,
+        "narHash": "sha256-P+v+nDOFWicM4wziFK9S/ajF2lc0N2Rg9p6Y35uMoZI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3bacde6273b09a21a8ccfba15586fb165078fb62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
         "home-manager": "home-manager"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "home-manager": {
+      "locked": {
+        "lastModified": 1672353432,
+        "narHash": "sha256-oZfgp/44/o2tWiylV30cR+DLyWTJ+5dhsdWZVpzs3e4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "913a47cd064cc06440ea84e5e0452039a85781f0",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-22.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  inputs = { home-manager.url = "nixpkgs/nixos-22.11"; };
+
+  outputs = { home-manager, ... }: {
+    nixosModules = rec {
+      default = gnome-manager;
+
+      gnome-manager = {
+        imports = [ home-manager.nixosModules.home-manager ./module.nix ];
+      };
+    };
+
+    homeManagerModules = rec {
+      default = gnome-manager;
+
+      gnome-manager = { config, lib, pkgs, ... }: {
+        imports = [ ./gnome.nix ];
+      };
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,7 @@
 {
-  inputs = { home-manager.url = "nixpkgs/nixos-22.11"; };
+  inputs = {
+    home-manager.url = "github:nix-community/home-manager/release-22.11";
+  };
 
   outputs = { home-manager, ... }: {
     nixosModules = rec {

--- a/flake.nix
+++ b/flake.nix
@@ -3,12 +3,14 @@
     home-manager.url = "github:nix-community/home-manager/release-22.11";
   };
 
-  outputs = { home-manager, ... }: {
+  outputs = { self, home-manager, ... }: {
     nixosModules = rec {
       default = gnome-manager;
 
       gnome-manager = {
         imports = [ home-manager.nixosModules.home-manager ./module.nix ];
+        config.home-manager.sharedModules =
+          [ self.homeManagerModules.gnome-manager ];
       };
     };
 

--- a/gnome.nix
+++ b/gnome.nix
@@ -1,84 +1,88 @@
-{ lib, pkgs, config, ... }:
-let normalUsers = builtins.filter(x: x.isNormalUser) config.users.users; in 
-{
-  imports = [
-    <home-manager/nixos>
-  ];
+{ config, lib, pkgs, ... }:
+with lib;
+let cfg = config.gnome-manager;
+in {
+  options.gnome-manager = with types; {
+    enable = lib.mkEnableOption "Enable GNOME management";
 
-  # Declaring option types
-  options = {
-    gnome-manager = {
-      enable = lib.mkEnableOption "Enable GNOME management";
+    user = mkOption {
+      type = str;
+      default = null;
+    };
 
-      user = lib.mkOption {
-        type = lib.types.str;
-        default = null;
-      };
+    background = mkOption {
+      type = str;
+      default = "${./smash_the_state.png}";
+    };
 
-      background = lib.mkOption {
-        type = lib.types.str;
-        default = "${./smash_the_state.png}";
-      };
+    keyboards = mkOption {
+      type = listOf str;
+      default = null;
+    };
 
-      keyboards = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        default = null;
-      };
-      
-      keybindings = lib.mkOption {
-        type = lib.types.attrs;
-        default = null;
-      };
+    keybindings = mkOption {
+      type = attrs;
+      default = null;
+    };
 
-      extensions = lib.mkOption {
-        #type = lib.types.listOf lib.types.package;
-        type = lib.types.listOf lib.types.str;
-        default = null;
-      };
+    extensions = mkOption {
+      type = listOf str;
+      default = null;
     };
   };
 
-  config = lib.mkIf config.gnome-manager.enable {
-    programs.dconf.enable = true;
+  config = mkIf cfg.enable {
+    dconf = {
+      enable = true;
 
-    home-manager.users."${config.gnome-manager.user}" = { lib, ... } : {
-      home.stateVersion = "22.11";
-
-      dconf.settings = {
+      settings = let
+        prefixFile = filename:
+          if hasPrefix filename then filename else "file://#{filename}";
+      in {
         # Background settings
-        "org/gnome/desktop/background" = lib.mkIf (builtins.hasAttr "background" config.gnome-manager) {
-          picture-uri = if lib.hasPrefix "file://" config.gnome-manager.background then config.gnome-manager.background
-                        else "file://" + config.gnome-manager.background;
-        };
-        "org/gnome/desktop/screensaver" = lib.mkIf (builtins.hasAttr "background" config.gnome-manager) {
-          picture-uri = if lib.hasPrefix "file://" config.gnome-manager.background then config.gnome-manager.background
-                        else "file://" + config.gnome-manager.background;
-        };
+        "org/gnome/desktop/background" =
+          mkIf (builtins.hasAttr "background" cfg) {
+            picture-uri = prefixFile cfg.background;
+          };
+
+        "org/gnome/desktop/screensaver" =
+          mkIf (builtins.hasAttr "background" cfg) {
+            picture-uri = prefixFile cfg.background;
+          };
 
         # Keyboard input settings
-        "org/gnome/desktop/input-sources" = lib.mkIf (builtins.hasAttr "keyboards" config.gnome-manager) {
-          sources = (map(x: (lib.hm.gvariant.mkTuple [ "xkb" x ])) config.gnome-manager.keyboards);
-        };
+        "org/gnome/desktop/input-sources" =
+          mkIf (builtins.hasAttr "keyboards" cfg) {
+            sources =
+              (map (x: (hm.gvariant.mkTuple [ "xkb" x ])) cfg.keyboards);
+          };
 
         # Extensions (1/2)
         # `gnome-extensions list` for a list of installed extensions
         "org/gnome/shell" = {
           disable-user-extensions = false;
-          enabled-extensions = if (builtins.hasAttr "extensions" config.gnome-manager) then builtins.map(x: pkgs.gnomeExtensions.${x}.extensionUuid) config.gnome-manager.extensions else [];
+          enabled-extensions = if (builtins.hasAttr "extensions" cfg) then
+            builtins.map (x: pkgs.gnomeExtensions.${x}.extensionUuid)
+            cfg.extensions
+          else
+            [ ];
         };
 
         # Keybindings
-        "org/gnome/desktop/wm/keybindings" = lib.mapAttrs (name: value:
+        "org/gnome/desktop/wm/keybindings" = mapAttrs (name: value:
           # Multiple keybindings
-          if lib.isList value then lib.hm.gvariant.mkValue value
-          # Single keybinding
-          else lib.hm.gvariant.mkValue [ value ]) config.gnome-manager.keybindings;
+          if isList value then
+            hm.gvariant.mkValue value
+            # Single keybinding
+          else
+            hm.gvariant.mkValue [ value ]) cfg.keybindings;
       };
-
-      # Extensions (2/2)
-      home.packages = if (builtins.hasAttr "extensions" config.gnome-manager) then builtins.map (x: pkgs.gnomeExtensions.${x}) config.gnome-manager.extensions else [];
-
     };
+
+    # Extensions (2/2)
+    home.packages = if (builtins.hasAttr "extensions" cfg) then
+      builtins.map (x: pkgs.gnomeExtensions.${x}) cfg.extensions
+    else
+      [ ];
   };
 }
-

--- a/gnome.nix
+++ b/gnome.nix
@@ -5,11 +5,6 @@ in {
   options.gnome-manager = with types; {
     enable = lib.mkEnableOption "Enable GNOME management";
 
-    user = mkOption {
-      type = str;
-      default = null;
-    };
-
     background = mkOption {
       type = str;
       default = "${./smash_the_state.png}";

--- a/module.nix
+++ b/module.nix
@@ -1,0 +1,18 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.gnome-manager;
+
+in {
+  options.gnome-manager = with types; {
+    enable = mkEnableOption "Enable Gnome configuration via Home Manager.";
+  };
+
+  config = mkIf cfg.enable {
+    programs.dconf.enable = true;
+
+    home-manager.users =
+      let regularUsers = filterAttrs (_: userOpts: userOpts.isNormalUser);
+      in mapAttrs (username: _: import ./gnome.nix) regularUsers;
+  };
+}


### PR DESCRIPTION
NOTE: This mostly untested. I don't have access to a NixOS machine at the
moment, so I can't test the NixOS module. I'm sending this more as a suggestion
for roughly how Gnome Manager could be laid out.

Moves from a NixOS module to a Home Manager module.

Adds a flake with two outputs:

 - A Home Manager module which can be used to add Gnome Manager support to a
   Home Manager config.
   
   In a flake, this would look something like:
   
   ```
     outputs = { home-manager, gnome-manager, ... }: {
       homeConfigurations.<someuser> = home-manager.lib.homeManagerConfiguration {
         modules = [ gnome-manager.homeManagerModules.default ];
       };
     }
   ```
   
   Note that this isn't standard, and `nix flake` will complain about
   homeManagerModules being an unrecognized output. AFAIK there isn't an
   official output for HM modules. However...it does work.
   
 - A NixOS module, which can be used in NixOS configs to add Gnome Manager
   system-wide.
   
   In a flake:
   
   ```
     outputs = { gnome-manager, ... }: {
       imports = [
         gnome-manager.nixosModules.default
         ./configuration.nix
       ];
     };
   ```
   
   ...At which point, you should be able to add settings to your NixOS config
   (say, in `configuration.nix`):
   
   ```
     { config, lib, pkgs, ... }: {
       config = {
         gnome-manager.enable = true;
         home-manager.users.<someuser>.gnome-manager.background = ./some-file.jpg;
       };
     }
   ```
   
It's also possible to use this without flakes, just by importing the file
`gnome.nix` into your __Home Manager_ config (not your NixOS config). To be
clear, in `configuration.nix` that would be:

```
  {
    home-manager.user.<someuser>.imports = [ /path/to/gnome.nix ];
  }
```

(...I think.)

Commits:

- Converted to Home Manager module
- Remove unused user option
